### PR TITLE
Correct resources of 'functionalTest' task

### DIFF
--- a/gradle/functional-test.gradle
+++ b/gradle/functional-test.gradle
@@ -4,7 +4,7 @@
 sourceSets {
 	functionalTest {
 		groovy.srcDir file('src/functionalTest/groovy')
-		resources.srcDir file('src/functionalTest/resources')
+		resources.srcDir file('src/functionalTest/testfiles')
 		compileClasspath += sourceSets.main.output + configurations.testRuntime
 		runtimeClasspath += output + compileClasspath
 	}


### PR DESCRIPTION
Hello

This commit fixes a bug in build script.
Specifically, it fixes the path to the resources of the `functionalTest` task.

The correct path is `src/functionalTest/testfiles`.